### PR TITLE
feat: whitelist merkle tree

### DIFF
--- a/src/interfaces/minter.cairo
+++ b/src/interfaces/minter.cairo
@@ -49,7 +49,7 @@ namespace ICarbonableMinter:
     ):
     end
 
-    func set_merkle_root(merkle_root : felt):
+    func set_whitelist_merkle_root(whitelist_merkle_root : felt):
     end
 
     func set_public_sale_open(public_sale_open : felt):

--- a/src/interfaces/minter.cairo
+++ b/src/interfaces/minter.cairo
@@ -39,12 +39,17 @@ namespace ICarbonableMinter:
     ###
     # Get the reserved slots number of the specified address.
     # @param account the specified account
+    # @param slots the expected slots
+    # @param proof_len the len of proof array
+    # @param proof the proof array
     # @return the number of reserved slots
     ###
-    func whitelist(account : felt) -> (slots : felt):
+    func whitelisted_slots(account : felt, slots : felt, proof_len : felt, proof : felt*) -> (
+        slots : felt
+    ):
     end
 
-    func set_whitelisted_sale_open(whitelisted_sale_open : felt):
+    func set_merkle_root(merkle_root : felt):
     end
 
     func set_public_sale_open(public_sale_open : felt):
@@ -56,7 +61,9 @@ namespace ICarbonableMinter:
     func set_unit_price(unit_price : Uint256):
     end
 
-    func add_to_whitelist(account : felt, slots : felt) -> (success : felt):
+    func whitelist_buy(slots : felt, proof_len : felt, proof : felt*, quantity : felt) -> (
+        success : felt
+    ):
     end
 
     func airdrop(to : felt, quantity : felt) -> (success : felt):

--- a/src/interfaces/minter.cairo
+++ b/src/interfaces/minter.cairo
@@ -36,6 +36,9 @@ namespace ICarbonableMinter:
     func reserved_supply_for_mint() -> (reserved_supply_for_mint : Uint256):
     end
 
+    func whitelist_merkle_root() -> (whitelist_merkle_root : felt):
+    end
+
     ###
     # Get the reserved slots number of the specified address.
     # @param account the specified account
@@ -61,11 +64,6 @@ namespace ICarbonableMinter:
     func set_unit_price(unit_price : Uint256):
     end
 
-    func whitelist_buy(slots : felt, proof_len : felt, proof : felt*, quantity : felt) -> (
-        success : felt
-    ):
-    end
-
     func airdrop(to : felt, quantity : felt) -> (success : felt):
     end
 
@@ -75,6 +73,11 @@ namespace ICarbonableMinter:
     func transfer(token_address : felt, recipient : felt, amount : Uint256) -> (success : felt):
     end
 
-    func buy(quantity : felt) -> (success : felt):
+    func whitelist_buy(slots : felt, proof_len : felt, proof : felt*, quantity : felt) -> (
+        success : felt
+    ):
+    end
+
+    func public_buy(quantity : felt) -> (success : felt):
     end
 end

--- a/src/mint/merkletree.cairo
+++ b/src/mint/merkletree.cairo
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: MIT
+# Carbonable smart contracts written in Cairo v0.1.0 (mint/merkletree.cairo)
+
+%lang starknet
+
+# Starkware dependencies
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.hash import hash2
+from starkware.cairo.common.math_cmp import is_le_felt
+
+namespace MerkleTree:
+    ###
+    # Verify that leaf belongs to merkle tree.
+    # ref: https://github.com/ncitron/cairo-merkle-distributor/blob/master/contracts/merkle.cairo
+    # @param leaf
+    # @param proof_len
+    # @param proof
+    ###
+    func verify{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        leaf : felt, merkle_root : felt, proof_len : felt, proof : felt*
+    ) -> (res : felt):
+        alloc_locals
+
+        let (calc_root) = calculate_root(leaf, proof_len, proof)
+        # check if calculated root is equal to expected
+        if calc_root == merkle_root:
+            return (1)
+        end
+        return (0)
+    end
+
+    ###
+    # Calculates the merkle root of a given proof
+    # ref: https://github.com/ncitron/cairo-merkle-distributor/blob/master/contracts/merkle.cairo
+    # @param curr
+    # @param proof_len
+    # @param proof
+    ###
+    func calculate_root{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        curr : felt, proof_len : felt, proof : felt*
+    ) -> (res : felt):
+        alloc_locals
+
+        if proof_len == 0:
+            return (curr)
+        end
+
+        local node
+        local proof_elem = [proof]
+        let (le) = is_le_felt(curr, proof_elem)
+
+        if le == 1:
+            let (n) = hash2{hash_ptr=pedersen_ptr}(curr, proof_elem)
+            node = n
+        else:
+            let (n) = hash2{hash_ptr=pedersen_ptr}(proof_elem, curr)
+            node = n
+        end
+
+        let (res) = calculate_root(node, proof_len - 1, proof + 1)
+        return (res)
+    end
+end

--- a/src/mint/minter.cairo
+++ b/src/mint/minter.cairo
@@ -68,7 +68,7 @@ end
 
 @view
 func whitelist_merkle_root{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
-    root : felt
+    whitelist_merkle_root : felt
 ):
     return CarbonableMinter.whitelist_merkle_root()
 end
@@ -140,13 +140,6 @@ func set_unit_price{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_chec
 end
 
 @external
-func whitelist_buy{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    slots : felt, proof_len : felt, proof : felt*, quantity : felt
-) -> (success : felt):
-    return CarbonableMinter.whitelist_buy(slots, proof_len, proof, quantity)
-end
-
-@external
 func airdrop{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     to : felt, quantity : felt
 ) -> (success : felt):
@@ -168,8 +161,15 @@ func transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}
 end
 
 @external
-func buy{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(quantity : felt) -> (
-    success : felt
-):
-    return CarbonableMinter.buy(quantity)
+func whitelist_buy{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    slots : felt, proof_len : felt, proof : felt*, quantity : felt
+) -> (success : felt):
+    return CarbonableMinter.whitelist_buy(slots, proof_len, proof, quantity)
+end
+
+@external
+func public_buy{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    quantity : felt
+) -> (success : felt):
+    return CarbonableMinter.public_buy(quantity)
 end

--- a/src/mint/minter.cairo
+++ b/src/mint/minter.cairo
@@ -67,10 +67,10 @@ func max_supply_for_mint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range
 end
 
 @view
-func merkle_root{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+func whitelist_merkle_root{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
     root : felt
 ):
-    return CarbonableMinter.merkle_root()
+    return CarbonableMinter.whitelist_merkle_root()
 end
 
 @view
@@ -112,10 +112,10 @@ end
 # ------------------
 
 @external
-func set_merkle_root{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    merkle_root : felt
+func set_whitelist_merkle_root{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    whitelist_merkle_root : felt
 ):
-    return CarbonableMinter.set_merkle_root(merkle_root)
+    return CarbonableMinter.set_whitelist_merkle_root(whitelist_merkle_root)
 end
 
 @external

--- a/src/mint/minter.cairo
+++ b/src/mint/minter.cairo
@@ -67,10 +67,17 @@ func max_supply_for_mint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range
 end
 
 @view
-func whitelist{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    account : felt
+func merkle_root{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    root : felt
+):
+    return CarbonableMinter.merkle_root()
+end
+
+@view
+func whitelisted_slots{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    account : felt, slots : felt, proof_len : felt, proof : felt*
 ) -> (slots : felt):
-    return CarbonableMinter.whitelist(account)
+    return CarbonableMinter.whitelisted_slots(account, slots, proof_len, proof)
 end
 
 # ------
@@ -82,7 +89,6 @@ func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     owner : felt,
     project_nft_address : felt,
     payment_token_address : felt,
-    whitelisted_sale_open : felt,
     public_sale_open : felt,
     max_buy_per_tx : felt,
     unit_price : Uint256,
@@ -93,7 +99,6 @@ func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
         owner,
         project_nft_address,
         payment_token_address,
-        whitelisted_sale_open,
         public_sale_open,
         max_buy_per_tx,
         unit_price,
@@ -107,10 +112,10 @@ end
 # ------------------
 
 @external
-func set_whitelisted_sale_open{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    whitelisted_sale_open : felt
+func set_merkle_root{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    merkle_root : felt
 ):
-    return CarbonableMinter.set_whitelisted_sale_open(whitelisted_sale_open)
+    return CarbonableMinter.set_merkle_root(merkle_root)
 end
 
 @external
@@ -135,10 +140,10 @@ func set_unit_price{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_chec
 end
 
 @external
-func add_to_whitelist{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    account : felt, slots : felt
+func whitelist_buy{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    slots : felt, proof_len : felt, proof : felt*, quantity : felt
 ) -> (success : felt):
-    return CarbonableMinter.add_to_whitelist(account, slots)
+    return CarbonableMinter.whitelist_buy(slots, proof_len, proof, quantity)
 end
 
 @external

--- a/tests/integrations/library.cairo
+++ b/tests/integrations/library.cairo
@@ -170,7 +170,7 @@ namespace carbonable_minter_instance:
     func whitelist{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, carbonable_minter : felt
     }() -> (root : felt):
-        let (root) = ICarbonableMinter.merkle_root(carbonable_minter)
+        let (root) = ICarbonableMinter.whitelist_merkle_root(carbonable_minter)
         return (root)
     end
 
@@ -196,9 +196,9 @@ namespace carbonable_minter_instance:
 
     func set_whitelisted_sale_open{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, carbonable_minter : felt
-    }(merkle_root : felt, caller : felt):
+    }(whitelist_merkle_root : felt, caller : felt):
         %{ stop_prank = start_prank(caller_address=ids.caller, target_contract_address=ids.carbonable_minter) %}
-        ICarbonableMinter.set_merkle_root(carbonable_minter, merkle_root)
+        ICarbonableMinter.set_whitelist_merkle_root(carbonable_minter, whitelist_merkle_root)
         %{ stop_prank() %}
         return ()
     end
@@ -299,8 +299,10 @@ namespace admin_instance:
         let (carbonable_minter) = carbonable_minter_instance.deployed()
         let (caller) = admin_instance.get_address()
         with carbonable_minter:
-            carbonable_minter_instance.set_merkle_root(merkle_root=root, caller=caller)
-            let (returned_root) = carbonable_minter_instance.merkle_root()
+            carbonable_minter_instance.set_whitelist_merkle_root(
+                whitelist_merkle_root=root, caller=caller
+            )
+            let (returned_root) = carbonable_minter_instance.whitelist_merkle_root()
             assert returned_root = root
         end
         return ()
@@ -488,7 +490,7 @@ namespace anyone_instance:
 
         # make the user to buy the quantity
         with carbonable_minter:
-            let (root) = carbonable_minter_instance.merkle_root()
+            let (root) = carbonable_minter_instance.whitelist_merkle_root()
             let (unit_price) = carbonable_minter_instance.unit_price()
             let (success) = carbonable_minter_instance.whitelist_buy(
                 slots=slots, proof_len=proof_len, proof=proof, quantity=quantity, caller=caller

--- a/tests/integrations/library.cairo
+++ b/tests/integrations/library.cairo
@@ -4,6 +4,7 @@
 %lang starknet
 
 # Starkware dependencies
+from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.bool import TRUE, FALSE
 from starkware.cairo.common.uint256 import Uint256
@@ -168,8 +169,17 @@ namespace carbonable_minter_instance:
 
     func whitelist{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, carbonable_minter : felt
-    }(account : felt) -> (slots : felt):
-        let (slots) = ICarbonableMinter.whitelist(carbonable_minter, account)
+    }() -> (root : felt):
+        let (root) = ICarbonableMinter.merkle_root(carbonable_minter)
+        return (root)
+    end
+
+    func whitelisted_slots{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, carbonable_minter : felt
+    }(account : felt, slots : felt, proof_len : felt, proof : felt*) -> (slots : felt):
+        let (slots) = ICarbonableMinter.whitelisted_slots(
+            carbonable_minter, account, slots, proof_len, proof
+        )
         return (slots)
     end
 
@@ -186,9 +196,9 @@ namespace carbonable_minter_instance:
 
     func set_whitelisted_sale_open{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, carbonable_minter : felt
-    }(whitelisted_sale_open : felt, caller : felt):
+    }(merkle_root : felt, caller : felt):
         %{ stop_prank = start_prank(caller_address=ids.caller, target_contract_address=ids.carbonable_minter) %}
-        ICarbonableMinter.set_whitelisted_sale_open(carbonable_minter, whitelisted_sale_open)
+        ICarbonableMinter.set_merkle_root(carbonable_minter, merkle_root)
         %{ stop_prank() %}
         return ()
     end
@@ -220,20 +230,24 @@ namespace carbonable_minter_instance:
         return ()
     end
 
-    func add_to_whitelist{
+    func whitelist_buy{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, carbonable_minter : felt
-    }(account : felt, slots : felt, caller : felt) -> (success : felt):
+    }(slots : felt, proof_len : felt, proof : felt*, quantity : felt, caller : felt) -> (
+        success : felt
+    ):
         %{ stop_prank = start_prank(caller_address=ids.caller, target_contract_address=ids.carbonable_minter) %}
-        let (success) = ICarbonableMinter.add_to_whitelist(carbonable_minter, account, slots)
+        let (success) = ICarbonableMinter.whitelist_buy(
+            carbonable_minter, slots, proof_len, proof, quantity
+        )
         %{ stop_prank() %}
         return (success)
     end
 
-    func buy{
+    func public_buy{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, carbonable_minter : felt
     }(quantity : felt, caller : felt) -> (success : felt):
         %{ stop_prank = start_prank(caller_address=ids.caller, target_contract_address=ids.carbonable_minter) %}
-        let (success) = ICarbonableMinter.buy(carbonable_minter, quantity)
+        let (success) = ICarbonableMinter.public_buy(carbonable_minter, quantity)
         %{ stop_prank() %}
         return (success)
     end
@@ -285,12 +299,9 @@ namespace admin_instance:
         let (carbonable_minter) = carbonable_minter_instance.deployed()
         let (caller) = admin_instance.get_address()
         with carbonable_minter:
-            carbonable_minter_instance.set_whitelisted_sale_open(
-                whitelisted_sale_open=whitelisted_sale_open, caller=caller
-            )
-            let (returned_whitelisted_sale_open) = carbonable_minter_instance.whitelisted_sale_open(
-                )
-            assert returned_whitelisted_sale_open = whitelisted_sale_open
+            carbonable_minter_instance.set_merkle_root(merkle_root=root, caller=caller)
+            let (returned_root) = carbonable_minter_instance.merkle_root()
+            assert returned_root = root
         end
         return ()
     end
@@ -334,22 +345,6 @@ namespace admin_instance:
             carbonable_minter_instance.set_unit_price(unit_price=unit_price, caller=caller)
             let (returned_unit_price) = carbonable_minter_instance.unit_price()
             assert returned_unit_price = unit_price
-        end
-        return ()
-    end
-
-    func add_to_whitelist{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        account : felt, slots : felt
-    ):
-        let (carbonable_minter) = carbonable_minter_instance.deployed()
-        let (caller) = admin_instance.get_address()
-        with carbonable_minter:
-            let (success) = carbonable_minter_instance.add_to_whitelist(
-                account=account, slots=slots, caller=caller
-            )
-            assert success = TRUE
-            let (returned_slots) = carbonable_minter_instance.whitelist(account=account)
-            assert returned_slots = slots
         end
         return ()
     end
@@ -422,6 +417,28 @@ namespace anyone_instance:
         return (anyone)
     end
 
+    func get_slots() -> (slots : felt):
+        tempvar slots
+        %{ ids.slots = context.SLOTS %}
+        return (slots)
+    end
+
+    func get_proof_len() -> (proof_len : felt):
+        tempvar proof_len
+        %{ ids.proof_len = context.PROOF_LEN %}
+        return (proof_len)
+    end
+
+    func get_proof() -> (proof : felt*):
+        alloc_locals
+        let (proof : felt*) = alloc()
+        %{
+            for index, node in enumerate(context.PROOF):
+                memory[ids.proof + index] = node
+        %}
+        return (proof)
+    end
+
     # Externals
 
     func approve{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
@@ -448,7 +465,63 @@ namespace anyone_instance:
         return ()
     end
 
-    func buy{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(quantity : felt):
+    func whitelist_buy{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        quantity : felt
+    ):
+        alloc_locals
+        let (carbonable_minter) = carbonable_minter_instance.deployed()
+        let (project_nft) = project_nft_instance.deployed()
+        let (payment_token) = payment_token_instance.deployed()
+        let (caller) = anyone_instance.get_address()
+        let (slots) = anyone_instance.get_slots()
+        let (proof_len) = anyone_instance.get_proof_len()
+        let (proof) = anyone_instance.get_proof()
+
+        # get user nft and payment token balances to check after buy
+        with project_nft:
+            let (initial_quantity) = project_nft_instance.balanceOf(owner=caller)
+            let (intial_total_supply) = project_nft_instance.totalSupply()
+        end
+        with payment_token:
+            let (initial_balance) = payment_token_instance.balanceOf(account=caller)
+        end
+
+        # make the user to buy the quantity
+        with carbonable_minter:
+            let (root) = carbonable_minter_instance.merkle_root()
+            let (unit_price) = carbonable_minter_instance.unit_price()
+            let (success) = carbonable_minter_instance.whitelist_buy(
+                slots=slots, proof_len=proof_len, proof=proof, quantity=quantity, caller=caller
+            )
+            assert success = TRUE
+        end
+
+        # check total supply and user nft quantity after buy
+        with project_nft:
+            let (returned_total_supply) = project_nft_instance.totalSupply()
+            let (expected_total_supply) = SafeUint256.sub_le(
+                returned_total_supply, intial_total_supply
+            )
+            assert expected_total_supply = Uint256(quantity, 0)
+
+            let (returned_quantity) = project_nft_instance.balanceOf(owner=caller)
+            let (expected_quantity) = SafeUint256.sub_le(returned_quantity, initial_quantity)
+            assert expected_quantity = Uint256(quantity, 0)
+        end
+
+        # check user payment token balance after buy
+        with payment_token:
+            let (returned_balance) = payment_token_instance.balanceOf(account=caller)
+            let (expected_spend) = SafeUint256.sub_le(initial_balance, returned_balance)
+            let (spend) = SafeUint256.mul(Uint256(quantity, 0), unit_price)
+            assert expected_spend = spend
+        end
+        return ()
+    end
+
+    func public_buy{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        quantity : felt
+    ):
         alloc_locals
         let (carbonable_minter) = carbonable_minter_instance.deployed()
         let (project_nft) = project_nft_instance.deployed()
@@ -467,7 +540,7 @@ namespace anyone_instance:
         # make the user to buy the quantity
         with carbonable_minter:
             let (unit_price) = carbonable_minter_instance.unit_price()
-            let (success) = carbonable_minter_instance.buy(quantity=quantity, caller=caller)
+            let (success) = carbonable_minter_instance.public_buy(quantity=quantity, caller=caller)
             assert success = TRUE
         end
 

--- a/tests/integrations/library.cairo
+++ b/tests/integrations/library.cairo
@@ -167,11 +167,11 @@ namespace carbonable_minter_instance:
         return (reserved_supply_for_mint)
     end
 
-    func whitelist{
+    func whitelist_merkle_root{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, carbonable_minter : felt
-    }() -> (root : felt):
-        let (root) = ICarbonableMinter.whitelist_merkle_root(carbonable_minter)
-        return (root)
+    }() -> (whitelist_merkle_root : felt):
+        let (whitelist_merkle_root) = ICarbonableMinter.whitelist_merkle_root(carbonable_minter)
+        return (whitelist_merkle_root)
     end
 
     func whitelisted_slots{
@@ -194,7 +194,7 @@ namespace carbonable_minter_instance:
         return (success)
     end
 
-    func set_whitelisted_sale_open{
+    func set_whitelist_merkle_root{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, carbonable_minter : felt
     }(whitelist_merkle_root : felt, caller : felt):
         %{ stop_prank = start_prank(caller_address=ids.caller, target_contract_address=ids.carbonable_minter) %}
@@ -293,17 +293,18 @@ namespace admin_instance:
         return ()
     end
 
-    func set_whitelisted_sale_open{
+    func set_whitelist_merkle_root{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
-    }(whitelisted_sale_open : felt):
+    }(whitelist_merkle_root : felt):
         let (carbonable_minter) = carbonable_minter_instance.deployed()
         let (caller) = admin_instance.get_address()
         with carbonable_minter:
             carbonable_minter_instance.set_whitelist_merkle_root(
-                whitelist_merkle_root=root, caller=caller
+                whitelist_merkle_root=whitelist_merkle_root, caller=caller
             )
-            let (returned_root) = carbonable_minter_instance.whitelist_merkle_root()
-            assert returned_root = root
+            let (returned_whitelist_merkle_root) = carbonable_minter_instance.whitelist_merkle_root(
+                )
+            assert returned_whitelist_merkle_root = whitelist_merkle_root
         end
         return ()
     end
@@ -490,7 +491,7 @@ namespace anyone_instance:
 
         # make the user to buy the quantity
         with carbonable_minter:
-            let (root) = carbonable_minter_instance.whitelist_merkle_root()
+            let (whitelist_merkle_root) = carbonable_minter_instance.whitelist_merkle_root()
             let (unit_price) = carbonable_minter_instance.unit_price()
             let (success) = carbonable_minter_instance.whitelist_buy(
                 slots=slots, proof_len=proof_len, proof=proof, quantity=quantity, caller=caller

--- a/tests/integrations/test_nominal_case.cairo
+++ b/tests/integrations/test_nominal_case.cairo
@@ -20,7 +20,7 @@ from tests.integrations.library import (
 func __setup__{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
     alloc_locals
     tempvar carbonable_minter
-    tempvar merkle_root = 3236969588476960619958150604131083087415975923122021901088942336874683133579
+    tempvar whitelist_merkle_root = 3236969588476960619958150604131083087415975923122021901088942336874683133579
     %{
         # --- INITIAL SETTINGS ---
         # User addresses
@@ -82,7 +82,7 @@ func __setup__{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
 
     # Transfer project nft ownershop from admin to minter
     admin.transferOwnership(carbonable_minter)
-    admin.set_merkle_root(merkle_root)
+    admin.set_whitelist_merkle_root(whitelist_merkle_root)
 
     return ()
 end
@@ -94,7 +94,7 @@ func test_e2e_not_whitelisted{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
     # - whitelisted: FALSE
     # - has enough funds: YES
 
-    admin.set_merkle_root(123)
+    admin.set_whitelist_merkle_root(123)
     anyone.approve(quantity=1)
     %{ expect_revert("TRANSACTION_FAILED", "CarbonableMinter: caller address is not whitelisted") %}
     anyone.whitelist_buy(quantity=1)

--- a/tests/units/test_minter.cairo
+++ b/tests/units/test_minter.cairo
@@ -40,7 +40,7 @@ struct TestContext:
     member signers : Signers
     member mocks : Mocks
 
-    member merkle_root : felt
+    member whitelist_merkle_root : felt
     member public_sale_open : felt
     member max_buy_per_tx : felt
     member unit_price : Uint256
@@ -225,7 +225,7 @@ func test_buy_revert_not_whitelisted{
 end
 
 @external
-func test_set_merkle_root_nominal_case{
+func test_set_whitelist_merkle_root_nominal_case{
     syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
 }():
     alloc_locals
@@ -446,7 +446,7 @@ end
 
 namespace test_internal:
     func prepare{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        merkle_root : felt,
+        whitelist_merkle_root : felt,
         public_sale_open : felt,
         max_buy_per_tx : felt,
         unit_price : Uint256,
@@ -464,7 +464,7 @@ namespace test_internal:
         local context : TestContext = TestContext(
             signers=signers,
             mocks=mocks,
-            merkle_root=merkle_root,
+            whitelist_merkle_root=whitelist_merkle_root,
             public_sale_open=public_sale_open,
             max_buy_per_tx=max_buy_per_tx,
             unit_price=unit_price,
@@ -483,9 +483,9 @@ namespace test_internal:
             context.reserved_supply_for_mint,
         )
 
-        # Admin adds merkle_root including anyone_1 with 5 slots
+        # Admin adds whitelist_merkle_root including anyone_1 with 5 slots
         %{ stop=start_prank(ids.context.signers.admin) %}
-        CarbonableMinter.set_merkle_root(context.merkle_root)
+        CarbonableMinter.set_whitelist_merkle_root(context.whitelist_merkle_root)
         %{ stop() %}
 
         return (test_context=context)


### PR DESCRIPTION
It fixes #12 

- [x] add a function in the smart contract to set the merkle root, callable only by owner
- [x] remove mapping storage
- [x] split the buy function in 2 functions, one for the public buy and one for the whitelisted buy. The reason is that they will take different arguments, the whitelisted buy needs the merkle proof
- [x] handle the verification of the merkle proof